### PR TITLE
Support check_shapes with partial functions

### DIFF
--- a/check_shapes/error_contexts.py
+++ b/check_shapes/error_contexts.py
@@ -323,7 +323,7 @@ class FunctionDefinitionContext(ErrorContext):
     func: Callable[..., Any]
 
     def print(self, builder: MessageBuilder) -> None:
-        name = self.func.__qualname__
+        name = getattr(self.func, "__qualname__", repr(self.func))
         try:
             path = inspect.getsourcefile(self.func)
         except Exception:  # pragma: no cover

--- a/tests/check_shapes/test_decorator.py
+++ b/tests/check_shapes/test_decorator.py
@@ -15,6 +15,7 @@
 # pylint: disable=unused-argument  # Bunch of fake functions below has unused arguments.
 
 from dataclasses import dataclass
+from functools import partial
 from typing import Mapping, Optional, Sequence, Tuple
 
 import pytest
@@ -779,3 +780,18 @@ def test_check_shapes__rewrites_docstring() -> None:
         """
         == f.__doc__
     )
+
+
+def test_check_shapes__supports_partial() -> None:
+    def f(a: TestShaped, d: int) -> TestShaped:
+        return t(3, d)
+
+    shape_check = check_shapes(
+        "a: [10]",
+        "return: [3, 10]",
+    )
+    partial_f = shape_check(partial(f, d=10))
+
+    partial_f(t(10))
+    with pytest.raises(ShapeMismatchError):
+        partial_f(t(5))


### PR DESCRIPTION
Calling check_shapes on partial function objects currently fails since these don't have a `__qualname__` (or `__name__`).