### PR TITLE
Include check_shapes as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 dropstackframe = ">=0.1.0"
 lark = "^1.1.0"
 python = "^3.7"
+check-shapes = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 Sphinx = "^5.2.2"


### PR DESCRIPTION
Because in pypi, it normalizes _ to -, `check_shapes` to `check-shapes`. Add this as dependency to become metapackage that pulls in the other.